### PR TITLE
Add 'GitHub Skills' activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First step in the GitHub Certifications program, great for college applications!",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing 'GitHub Skills' activity to the activities list, making it available for student registration as requested in issue #6. The new activity includes a description, schedule, and participant capacity. No other changes were made.